### PR TITLE
Make RYBitten default color mode and integrate rampensau library

### DIFF
--- a/code.js
+++ b/code.js
@@ -563,6 +563,303 @@ function k(t2, { cube: n2 = r, easingFn: s2 = g2 } = {}) {
   ];
 }
 
+// node_modules/rampensau/dist/index.mjs
+var __defProp = Object.defineProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var utils_exports = {};
+__export(utils_exports, {
+  lerp: () => lerp,
+  makeCurveEasings: () => makeCurveEasings,
+  pointOnCurve: () => pointOnCurve,
+  scaleSpreadArray: () => scaleSpreadArray,
+  shuffleArray: () => shuffleArray
+});
+function shuffleArray(array, rndFn = Math.random) {
+  const copy = [...array];
+  let currentIndex = copy.length, randomIndex;
+  while (currentIndex != 0) {
+    randomIndex = Math.floor(rndFn() * currentIndex);
+    currentIndex--;
+    [copy[currentIndex], copy[randomIndex]] = [
+      copy[randomIndex],
+      copy[currentIndex]
+    ];
+  }
+  return copy;
+}
+var lerp = (amt, from, to) => from + amt * (to - from);
+var scaleSpreadArray = (valuesToFill, targetSize, padding = 0, fillFunction = lerp) => {
+  if (!valuesToFill || valuesToFill.length < 2) {
+    throw new Error("valuesToFill array must have at least two values.");
+  }
+  if (targetSize < 1 && padding > 0) {
+    throw new Error("Target size must be at least 1");
+  }
+  if (targetSize < valuesToFill.length && padding === 0) {
+    throw new Error(
+      "Target size must be greater than or equal to the valuesToFill array length."
+    );
+  }
+  if (padding <= 0) {
+    const valuesToAdd = targetSize - valuesToFill.length;
+    const chunkArray = valuesToFill.map((value) => [value]);
+    for (let i2 = 0; i2 < valuesToAdd; i2++) {
+      const idx = i2 % (valuesToFill.length - 1);
+      if (idx >= 0 && idx < chunkArray.length) {
+        const chunk = chunkArray[idx];
+        if (chunk) {
+          chunk.push(null);
+        }
+      }
+    }
+    for (let i2 = 0; i2 < chunkArray.length - 1; i2++) {
+      const currentChunk = chunkArray[i2];
+      const nextChunk = chunkArray[i2 + 1];
+      if (!currentChunk || !nextChunk) {
+        continue;
+      }
+      const currentValue = currentChunk[0];
+      const nextValue = nextChunk[0];
+      if (currentValue === void 0 || nextValue === void 0) {
+        continue;
+      }
+      for (let j = 1; j < currentChunk.length; j++) {
+        const percent = j / currentChunk.length;
+        currentChunk[j] = fillFunction(percent, currentValue, nextValue);
+      }
+    }
+    return chunkArray.flat();
+  }
+  const result = [];
+  const domainStart = padding;
+  const domainEnd = 1 - padding;
+  for (let i2 = 0; i2 < targetSize; i2++) {
+    const t2 = targetSize === 1 ? 0.5 : i2 / (targetSize - 1);
+    const adjustedT = domainStart + t2 * (domainEnd - domainStart);
+    let segmentIndex = 0;
+    const normalizedPositions = valuesToFill.map(
+      (_2, i22) => i22 / (valuesToFill.length - 1)
+    );
+    for (let j = 1; j < normalizedPositions.length; j++) {
+      const position = normalizedPositions[j];
+      if (position !== void 0 && adjustedT <= position) {
+        segmentIndex = j - 1;
+        break;
+      }
+      if (j === normalizedPositions.length - 1) {
+        segmentIndex = j - 1;
+      }
+    }
+    segmentIndex = Math.min(Math.max(0, segmentIndex), valuesToFill.length - 2);
+    const segmentStart = normalizedPositions[segmentIndex] || 0;
+    const segmentEnd = normalizedPositions[segmentIndex + 1] || 1;
+    let segmentT = 0;
+    if (segmentEnd > segmentStart) {
+      segmentT = (adjustedT - segmentStart) / (segmentEnd - segmentStart);
+    }
+    const fromValue = valuesToFill[segmentIndex];
+    const toValue = valuesToFill[segmentIndex + 1];
+    if (fromValue === void 0 || toValue === void 0) {
+      throw new Error(`Invalid segment values at index ${segmentIndex}`);
+    }
+    const value = fillFunction(segmentT, fromValue, toValue);
+    result.push(value);
+  }
+  return result;
+};
+var pointOnCurve = (curveMethod, curveAccent) => {
+  return (t2) => {
+    const limit = Math.PI / 2;
+    const slice = limit / 1;
+    const percentile = t2;
+    let x = 0, y2 = 0;
+    if (curveMethod === "lam\xE9") {
+      const t22 = percentile * limit;
+      const exp = 2 / (2 + 20 * curveAccent);
+      const cosT = Math.cos(t22);
+      const sinT = Math.sin(t22);
+      x = Math.sign(cosT) * Math.abs(cosT) ** exp;
+      y2 = Math.sign(sinT) * Math.abs(sinT) ** exp;
+    } else if (curveMethod === "arc") {
+      y2 = Math.cos(-Math.PI / 2 + t2 * slice + curveAccent);
+      x = Math.sin(Math.PI / 2 + t2 * slice - curveAccent);
+    } else if (curveMethod === "pow") {
+      x = Math.pow(1 - percentile, 1 - curveAccent);
+      y2 = Math.pow(percentile, 1 - curveAccent);
+    } else if (curveMethod === "powY") {
+      x = Math.pow(1 - percentile, curveAccent);
+      y2 = Math.pow(percentile, 1 - curveAccent);
+    } else if (curveMethod === "powX") {
+      x = Math.pow(percentile, curveAccent);
+      y2 = Math.pow(percentile, 1 - curveAccent);
+    } else if (typeof curveMethod === "function") {
+      const [xFunc, yFunc] = curveMethod(t2, curveAccent);
+      x = xFunc;
+      y2 = yFunc;
+    } else {
+      throw new Error(
+        `pointOnCurve() curveAccent parameter is expected to be "lam\xE9" | "arc" | "pow" | "powY" | "powX" or a function but \`${curveMethod}\` given.`
+      );
+    }
+    return { x, y: y2 };
+  };
+};
+var makeCurveEasings = (curveMethod, curveAccent) => {
+  const point = pointOnCurve(curveMethod, curveAccent);
+  return {
+    sEasing: (t2) => point(t2).x,
+    lEasing: (t2) => point(t2).y
+  };
+};
+var colorUtils_exports = {};
+__export(colorUtils_exports, {
+  colorHarmonies: () => colorHarmonies,
+  colorToCSS: () => colorToCSS,
+  harveyHue: () => harveyHue,
+  hsv2hsl: () => hsv2hsl,
+  normalizeHue: () => normalizeHue,
+  uniqueRandomHues: () => uniqueRandomHues
+});
+function normalizeHue(h2) {
+  return (h2 % 360 + 360) % 360;
+}
+function harveyHue(h2) {
+  h2 = normalizeHue(h2) / 360;
+  if (h2 === 1 || h2 === 0) return h2;
+  h2 = 1 + h2 % 1;
+  const seg = 1 / 6;
+  const a2 = h2 % seg / seg * Math.PI / 2;
+  const [b2, c2] = [seg * Math.cos(a2), seg * Math.sin(a2)];
+  const i2 = Math.floor(h2 * 6);
+  const cases = [c2, 1 / 3 - b2, 1 / 3 + c2, 2 / 3 - b2, 2 / 3 + c2, 1 - b2];
+  return cases[i2 % 6] * 360;
+}
+var colorHarmonies = {
+  complementary: (h2) => [normalizeHue(h2), normalizeHue(h2 + 180)],
+  splitComplementary: (h2) => [
+    normalizeHue(h2),
+    normalizeHue(h2 + 150),
+    normalizeHue(h2 - 150)
+  ],
+  triadic: (h2) => [
+    normalizeHue(h2),
+    normalizeHue(h2 + 120),
+    normalizeHue(h2 + 240)
+  ],
+  tetradic: (h2) => [
+    normalizeHue(h2),
+    normalizeHue(h2 + 90),
+    normalizeHue(h2 + 180),
+    normalizeHue(h2 + 270)
+  ],
+  monochromatic: (h2) => [normalizeHue(h2), normalizeHue(h2)],
+  // min 2 for RampenSau
+  doubleComplementary: (h2) => [
+    normalizeHue(h2),
+    normalizeHue(h2 + 180),
+    normalizeHue(h2 + 30),
+    normalizeHue(h2 + 210)
+  ],
+  compound: (h2) => [
+    normalizeHue(h2),
+    normalizeHue(h2 + 180),
+    normalizeHue(h2 + 60),
+    normalizeHue(h2 + 240)
+  ],
+  analogous: (h2) => [
+    normalizeHue(h2),
+    normalizeHue(h2 + 30),
+    normalizeHue(h2 + 60),
+    normalizeHue(h2 + 90),
+    normalizeHue(h2 + 120),
+    normalizeHue(h2 + 150)
+  ]
+};
+function uniqueRandomHues({
+  startHue = 0,
+  total = 9,
+  minHueDiffAngle = 60,
+  rndFn = Math.random
+} = {}) {
+  minHueDiffAngle = Math.min(minHueDiffAngle, 360 / total);
+  const baseHue = startHue || rndFn() * 360;
+  const huesToPickFrom = Array.from(
+    {
+      length: Math.round(360 / minHueDiffAngle)
+    },
+    (_2, i2) => (baseHue + i2 * minHueDiffAngle) % 360
+  );
+  let randomizedHues = shuffleArray(huesToPickFrom, rndFn);
+  if (randomizedHues.length > total) {
+    randomizedHues = randomizedHues.slice(0, total);
+  }
+  return randomizedHues;
+}
+var hsv2hsl = ([h2, s2, v]) => {
+  const l3 = v - v * s2 / 2;
+  const m3 = Math.min(l3, 1 - l3);
+  const s_hsl = m3 === 0 ? 0 : (v - l3) / m3;
+  return [h2, s_hsl, l3];
+};
+var colorModsCSS = {
+  oklch: (color) => [color[2] * 100 + "%", color[1] * 100 + "%", color[0]],
+  lch: (color) => [color[2] * 100 + "%", color[1] * 100 + "%", color[0]],
+  hsl: (color) => [color[0], color[1] * 100 + "%", color[2] * 100 + "%"],
+  hsv: (color) => {
+    const [h2, s2, l3] = hsv2hsl(color);
+    return [h2, s2 * 100 + "%", l3 * 100 + "%"];
+  }
+};
+var colorToCSS = (color, mode = "oklch") => {
+  const cssMode = mode === "hsv" ? "hsl" : mode;
+  return `${cssMode}(${colorModsCSS[mode](color).join(" ")})`;
+};
+var generateColorRampParams = {
+  total: {
+    default: 5,
+    props: { min: 4, max: 50, step: 1 }
+  },
+  hStart: {
+    default: 0,
+    props: { min: 0, max: 360, step: 0.1 }
+  },
+  hCycles: {
+    default: 1,
+    props: { min: -2, max: 2, step: 1e-3 }
+  },
+  hStartCenter: {
+    default: 0.5,
+    props: { min: 0, max: 1, step: 1e-3 }
+  },
+  minLight: {
+    default: Math.random() * 0.2,
+    props: { min: 0, max: 1, step: 1e-3 }
+  },
+  maxLight: {
+    default: 0.89 + Math.random() * 0.11,
+    props: { min: 0, max: 1, step: 1e-3 }
+  },
+  minSaturation: {
+    default: Math.random() < 0.5 ? 0.4 : 0.8 + Math.random() * 0.2,
+    props: { min: 0, max: 1, step: 1e-3 }
+  },
+  maxSaturation: {
+    default: Math.random() < 0.5 ? 0.35 : 0.9 + Math.random() * 0.1,
+    props: { min: 0, max: 1, step: 1e-3 }
+  },
+  curveMethod: {
+    default: "lam\xE9",
+    props: { options: ["lam\xE9", "sine", "power", "linear"] }
+  },
+  curveAccent: {
+    default: 0.5,
+    props: { min: 0, max: 5, step: 0.01 }
+  }
+};
+
 // code.ts
 figma.showUI(__html__, { width: 400, height: 600 });
 figma.on("selectionchange", () => {
@@ -838,22 +1135,7 @@ function hslToRgb(h2, s2, l3) {
     b: Math.round(b2 * 255)
   };
 }
-function harveyHue(h2) {
-  const hNorm = h2 % 1;
-  let hTransformed;
-  if (hNorm < 0.0833) {
-    hTransformed = hNorm * 0.5 / 0.0833;
-  } else if (hNorm < 0.1667) {
-    hTransformed = 0.5 + (hNorm - 0.0833) * 0.5 / 0.0833;
-  } else if (hNorm < 0.5) {
-    hTransformed = 1 + (hNorm - 0.1667) * 2 / 0.3333;
-  } else if (hNorm < 0.8333) {
-    hTransformed = 3 + (hNorm - 0.5) * 2 / 0.3333;
-  } else {
-    hTransformed = 5 + (hNorm - 0.8333) * 1 / 0.1667;
-  }
-  return hTransformed / 6 % 1;
-}
+var { harveyHue: harveyHue2 } = utils_exports;
 function rgbToHsl(r2, g3, b2) {
   r2 /= 255;
   g3 /= 255;
@@ -884,10 +1166,11 @@ function rgbToHsl(r2, g3, b2) {
 }
 function applyTransform(rgb, transformFn, originalHue) {
   switch (transformFn) {
-    case "harveyHue":
+    case "harveyHue": {
       const hsl = rgbToHsl(rgb.r, rgb.g, rgb.b);
-      const transformedHue = harveyHue((originalHue || 0) / 360);
+      const transformedHue = harveyHue2((originalHue || 0) / 360);
       return hslToRgb(transformedHue, hsl.s, hsl.l);
+    }
     case "muted":
       return {
         r: Math.round(rgb.r * 0.8),

--- a/code.js
+++ b/code.js
@@ -886,7 +886,7 @@ figma.on("selectionchange", () => {
           easingCurve: values[12],
           transformFn: values[13],
           colorMode: values[14],
-          rybGamut: values[15] || "default"
+          rybGamut: values[15] || "itten"
         };
         figma.ui.postMessage({
           type: "load-config",
@@ -916,7 +916,7 @@ figma.ui.onmessage = async (msg) => {
       msg.config.easingCurve,
       msg.config.transformFn,
       msg.config.colorMode,
-      msg.config.rybGamut || "default"
+      msg.config.rybGamut || "itten"
     ].join("|");
     frame.name = `Color Palette [rampensau|${configString}]`;
     frame.layoutMode = "HORIZONTAL";
@@ -1051,7 +1051,7 @@ function generateColorPalette(config) {
       rgb = oklchToRgb(lightness / 100, saturation / 100 * 0.4, hue);
     } else if (config.colorMode === "rybitten") {
       const ryb = hslToRyb(hue / 360, saturation / 100, lightness / 100);
-      rgb = rybToRgb(ryb.r, ryb.y, ryb.b, config.rybGamut || "default");
+      rgb = rybToRgb(ryb.r, ryb.y, ryb.b, config.rybGamut || "itten");
     } else {
       rgb = hslToRgb(hue / 360, saturation / 100, lightness / 100);
     }

--- a/code.js
+++ b/code.js
@@ -1135,7 +1135,6 @@ function hslToRgb(h2, s2, l3) {
     b: Math.round(b2 * 255)
   };
 }
-var { harveyHue: harveyHue2 } = utils_exports;
 function rgbToHsl(r2, g3, b2) {
   r2 /= 255;
   g3 /= 255;
@@ -1168,7 +1167,7 @@ function applyTransform(rgb, transformFn, originalHue) {
   switch (transformFn) {
     case "harveyHue": {
       const hsl = rgbToHsl(rgb.r, rgb.g, rgb.b);
-      const transformedHue = harveyHue2((originalHue || 0) / 360);
+      const transformedHue = utils_exports.harveyHue((originalHue || 0) / 360);
       return hslToRgb(transformedHue, hsl.s, hsl.l);
     }
     case "muted":

--- a/code.ts
+++ b/code.ts
@@ -1,5 +1,6 @@
 import { ryb2rgb } from 'rybitten';
 import { cubes } from 'rybitten/cubes';
+import { utils } from 'rampensau';
 
 figma.showUI(__html__, { width: 400, height: 600 });
 
@@ -343,26 +344,8 @@ function hslToRgb(h: number, s: number, l: number): { r: number, g: number, b: n
   };
 }
 
-function harveyHue(h: number): number {
-  // Harvey Hue transformation to create more evenly distributed spectrum
-  // Based on Harvey Rayner's work, adapted for RampenSau
-  const hNorm = h % 1;
-  let hTransformed: number;
-  
-  if (hNorm < 0.0833) {
-    hTransformed = hNorm * 0.5 / 0.0833;
-  } else if (hNorm < 0.1667) {
-    hTransformed = 0.5 + (hNorm - 0.0833) * 0.5 / 0.0833;
-  } else if (hNorm < 0.5) {
-    hTransformed = 1 + (hNorm - 0.1667) * 2 / 0.3333;
-  } else if (hNorm < 0.8333) {
-    hTransformed = 3 + (hNorm - 0.5) * 2 / 0.3333;
-  } else {
-    hTransformed = 5 + (hNorm - 0.8333) * 1 / 0.1667;
-  }
-  
-  return (hTransformed / 6) % 1;
-}
+// Use harveyHue from rampensau utils
+const { harveyHue } = utils;
 
 function rgbToHsl(r: number, g: number, b: number): { h: number, s: number, l: number } {
   r /= 255;
@@ -393,11 +376,12 @@ function rgbToHsl(r: number, g: number, b: number): { h: number, s: number, l: n
 
 function applyTransform(rgb: { r: number, g: number, b: number }, transformFn: string, originalHue?: number): { r: number, g: number, b: number } {
   switch (transformFn) {
-    case 'harveyHue':
+    case 'harveyHue': {
       // Convert back to HSL, apply Harvey Hue, then back to RGB
       const hsl = rgbToHsl(rgb.r, rgb.g, rgb.b);
       const transformedHue = harveyHue((originalHue || 0) / 360);
       return hslToRgb(transformedHue, hsl.s, hsl.l);
+    }
     case 'muted':
       return {
         r: Math.round(rgb.r * 0.8),

--- a/code.ts
+++ b/code.ts
@@ -34,7 +34,7 @@ figma.on('selectionchange', () => {
           easingCurve: values[12],
           transformFn: values[13],
           colorMode: values[14],
-          rybGamut: values[15] || 'default'
+          rybGamut: values[15] || 'itten'
         };
         
         // Send configuration to UI
@@ -88,7 +88,7 @@ figma.ui.onmessage = async (msg: { type: string, config?: ColorPaletteConfig }) 
       msg.config.easingCurve,
       msg.config.transformFn,
       msg.config.colorMode,
-      msg.config.rybGamut || 'default'
+      msg.config.rybGamut || 'itten'
     ].join('|');
     frame.name = `Color Palette [rampensau|${configString}]`;
     frame.layoutMode = 'HORIZONTAL';
@@ -275,7 +275,7 @@ function generateColorPalette(config: ColorPaletteConfig): { r: number, g: numbe
     } else if (config.colorMode === 'rybitten') {
       // Convert HSL to RYB space
       const ryb = hslToRyb(hue / 360, saturation / 100, lightness / 100);
-      rgb = rybToRgb(ryb.r, ryb.y, ryb.b, config.rybGamut || 'default');
+      rgb = rybToRgb(ryb.r, ryb.y, ryb.b, config.rybGamut || 'itten');
     } else {
       rgb = hslToRgb(hue / 360, saturation / 100, lightness / 100);
     }

--- a/code.ts
+++ b/code.ts
@@ -345,7 +345,6 @@ function hslToRgb(h: number, s: number, l: number): { r: number, g: number, b: n
 }
 
 // Use harveyHue from rampensau utils
-const { harveyHue } = utils;
 
 function rgbToHsl(r: number, g: number, b: number): { h: number, s: number, l: number } {
   r /= 255;
@@ -379,7 +378,7 @@ function applyTransform(rgb: { r: number, g: number, b: number }, transformFn: s
     case 'harveyHue': {
       // Convert back to HSL, apply Harvey Hue, then back to RGB
       const hsl = rgbToHsl(rgb.r, rgb.g, rgb.b);
-      const transformedHue = harveyHue((originalHue || 0) / 360);
+      const transformedHue = utils.harveyHue((originalHue || 0) / 360);
       return hslToRgb(transformedHue, hsl.s, hsl.l);
     }
     case 'muted':

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "RampenSau",
       "version": "1.0.0",
       "dependencies": {
+        "rampensau": "^2.1.0",
         "rybitten": "^0.23.1"
       },
       "devDependencies": {
@@ -2002,6 +2003,12 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/rampensau": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/rampensau/-/rampensau-2.1.0.tgz",
+      "integrity": "sha512-A4HLTLjROtWF0HAfmd3qV26VSF6R9P18NlsZ+1qGOSSwdKylGco+7WIIRMG66g/LaiA4eBb7oCZn8AUSizTqiQ==",
       "license": "MIT"
     },
     "node_modules/resolve-from": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     }
   },
   "dependencies": {
+    "rampensau": "^2.1.0",
     "rybitten": "^0.23.1"
   }
 }

--- a/ui.html
+++ b/ui.html
@@ -407,6 +407,8 @@
   </div>
   
   <script>
+    console.log('[UI] Script starting...');
+    
     // Update range value displays and handle input changes
     document.querySelectorAll('input[type="range"]').forEach(input => {
       const valueInput = document.getElementById(input.id + 'Value');
@@ -811,10 +813,25 @@
     updatePreview();
     
     // Button handlers
-    document.getElementById('generate').onclick = () => {
-      const config = getConfig();
-      parent.postMessage({ pluginMessage: { type: 'generate-palette', config } }, '*');
-    };
+    const generateButton = document.getElementById('generate');
+    console.log('[UI] Generate button element:', generateButton);
+    
+    if (generateButton) {
+      generateButton.onclick = () => {
+        console.log('[UI] Generate button clicked');
+        try {
+          const config = getConfig();
+          console.log('[UI] Config:', config);
+          console.log('[UI] Sending message to plugin');
+          parent.postMessage({ pluginMessage: { type: 'generate-palette', config } }, '*');
+          console.log('[UI] Message sent successfully');
+        } catch (error) {
+          console.error('[UI] Error in generate button handler:', error);
+        }
+      };
+    } else {
+      console.error('[UI] Generate button not found!');
+    }
     
     document.getElementById('cancel').onclick = () => {
       parent.postMessage({ pluginMessage: { type: 'cancel' } }, '*');
@@ -822,8 +839,10 @@
     
     // Listen for messages from the plugin
     window.onmessage = (event) => {
+      console.log('[UI] Received message:', event.data);
       if (event.data.pluginMessage) {
         if (event.data.pluginMessage.type === 'palette-generated') {
+          console.log('[UI] Palette generated successfully');
           // Could show a success message or update UI
         } else if (event.data.pluginMessage.type === 'load-config') {
           // Load configuration into UI

--- a/ui.html
+++ b/ui.html
@@ -364,14 +364,13 @@
     <div class="control-group">
       <label>Color Mode</label>
       <select id="colorMode">
+        <option value="rybitten">RYBitten</option>
         <option value="hsl">HSL</option>
         <option value="oklch">OKLCH</option>
-        <option value="rybitten">RYBitten</option>
-        <option value="hsv">HSV (coming soon)</option>
       </select>
     </div>
     
-    <div class="control-group" id="rybGamutGroup" style="display: none;">
+    <div class="control-group" id="rybGamutGroup">
       <label>RYBitten Gamut</label>
       <select id="rybGamut">
         <option value="itten">Itten - Chromatic Circle (1961)</option>
@@ -734,8 +733,12 @@
     }
     
     function harveyHue(h) {
-      // Harvey Hue transformation to create more evenly distributed spectrum
-      // Based on Harvey Rayner's work, adapted for RampenSau
+      // Use harvey hue from rampensau if available, otherwise fall back to custom implementation
+      if (window.rampensauUtils && window.rampensauUtils.harveyHue) {
+        return window.rampensauUtils.harveyHue(h);
+      }
+      
+      // Fallback implementation
       const hNorm = h % 1;
       let hTransformed;
       

--- a/ui.html
+++ b/ui.html
@@ -663,7 +663,7 @@
           // For RYBitten, we'll need to handle this differently since we can't use npm modules in the UI
           // We'll keep the simplified version for preview and rely on the main code for actual generation
           const ryb = hslToRyb(hue / 360, saturation / 100, lightness / 100);
-          rgb = rybToRgb(ryb.r, ryb.y, ryb.b, config.rybGamut);
+          rgb = rybToRgb(ryb.r, ryb.y, ryb.b, config.rybGamut || 'itten');
         } else {
           rgb = hslToRgb(hue / 360, saturation / 100, lightness / 100);
         }

--- a/ui.html
+++ b/ui.html
@@ -408,6 +408,7 @@
   
   <script>
     console.log('[UI] Script starting...');
+    console.log('[UI] window.rybittenConvert available:', !!window.rybittenConvert);
     
     // Update range value displays and handle input changes
     document.querySelectorAll('input[type="range"]').forEach(input => {
@@ -589,11 +590,11 @@
       return { r: ry, y: y, b: by };
     }
     
-    function rybToRgb(r, y, b, gamut = 'itten') {
+    function rybToRgb(rVal, yVal, bVal, gamut = 'itten') {
       // Check if we have the real RYBitten library available
       if (window.rybittenConvert) {
         // Use the real RYBitten conversion
-        const rgb = window.rybittenConvert.ryb2rgb([r, y, b], gamut);
+        const rgb = window.rybittenConvert.ryb2rgb([rVal, yVal, bVal], gamut);
         return {
           r: Math.round(Math.max(0, Math.min(255, rgb[0] * 255))),
           g: Math.round(Math.max(0, Math.min(255, rgb[1] * 255))),
@@ -602,27 +603,27 @@
       } else {
         // Fallback to simple conversion if RYBitten not loaded yet
         // This is just a basic RYB to RGB conversion
-        const white = Math.min(r, y, b);
-        const red = r - white;
-        const yellow = y - white;
-        const blue = b - white;
+        const white = Math.min(rVal, yVal, bVal);
+        let redComp = rVal - white;
+        let yellowComp = yVal - white;
+        let blueComp = bVal - white;
         
-        const green = Math.min(yellow, blue);
-        yellow -= green;
-        blue -= green;
+        const greenComp = Math.min(yellowComp, blueComp);
+        yellowComp -= greenComp;
+        blueComp -= greenComp;
         
-        const orange = Math.min(red, yellow) * 0.5;
-        red -= orange;
-        yellow -= orange;
+        const orangeComp = Math.min(redComp, yellowComp) * 0.5;
+        redComp -= orangeComp;
+        yellowComp -= orangeComp;
         
-        const purple = Math.min(red, blue) * 0.5;
-        red -= purple;
-        blue -= purple;
+        const purpleComp = Math.min(redComp, blueComp) * 0.5;
+        redComp -= purpleComp;
+        blueComp -= purpleComp;
         
         return {
-          r: Math.round(Math.max(0, Math.min(255, (red + orange + purple + white) * 255))),
-          g: Math.round(Math.max(0, Math.min(255, (green + orange * 0.5 + white) * 255))),
-          b: Math.round(Math.max(0, Math.min(255, (blue + purple + white) * 255)))
+          r: Math.round(Math.max(0, Math.min(255, (redComp + orangeComp + purpleComp + white) * 255))),
+          g: Math.round(Math.max(0, Math.min(255, (greenComp + orangeComp * 0.5 + white) * 255))),
+          b: Math.round(Math.max(0, Math.min(255, (blueComp + purpleComp + white) * 255)))
         };
       }
     }
@@ -809,8 +810,15 @@
       return { h, s, l };
     }
     
-    // Initial preview
-    updatePreview();
+    // Initial preview - delay to ensure bundle loads first
+    setTimeout(() => {
+      console.log('[UI] Delayed check - window.rybittenConvert available:', !!window.rybittenConvert);
+      try {
+        updatePreview();
+      } catch (error) {
+        console.error('[UI] Error in initial updatePreview:', error);
+      }
+    }, 100);
     
     // Button handlers
     const generateButton = document.getElementById('generate');

--- a/ui.ts
+++ b/ui.ts
@@ -1,8 +1,27 @@
 import { ryb2rgb } from 'rybitten';
 import { cubes } from 'rybitten/cubes';
+import { utils } from 'rampensau';
+
+// Define the rybittenConvert interface
+interface RybittenConvert {
+  ryb2rgb: (coords: [number, number, number], gamutName: string) => number[];
+  getAvailableGamuts: () => { [key: string]: string };
+}
+
+// Define the rampensau utils interface  
+interface RampensauUtils {
+  harveyHue: (h: number) => number;
+}
 
 // Expose RYBitten functions to the global window object for the UI
-(window as any).rybittenConvert = {
+declare global {
+  interface Window {
+    rybittenConvert: RybittenConvert;
+    rampensauUtils: RampensauUtils;
+  }
+}
+
+window.rybittenConvert = {
   ryb2rgb: (coords: [number, number, number], gamutName: string) => {
     const cubeData = cubes.get(gamutName);
     const cube = cubeData ? cubeData.cube : undefined;
@@ -17,4 +36,9 @@ import { cubes } from 'rybitten/cubes';
     });
     return gamutList;
   }
+};
+
+// Expose rampensau utils
+window.rampensauUtils = {
+  harveyHue: utils.harveyHue
 };


### PR DESCRIPTION
## Summary
- Made RYBitten the default color mode instead of HSL
- Removed HSV color mode option that was marked as "coming soon"
- Integrated the official rampensau library for harvey hue function

## Changes
1. **UI Updates**:
   - Reordered color mode dropdown to show RYBitten first
   - Removed HSV option from the dropdown
   - RYBitten gamut selector is now visible by default

2. **Code Improvements**:
   - Added rampensau as a dependency
   - Replaced custom harvey hue implementation with the official one from rampensau utils
   - Fixed TypeScript linting errors for better code quality
   - Properly typed the window.rybittenConvert interface

## Test Plan
- [ ] Build the plugin with `npm run build`
- [ ] Verify RYBitten appears as the default color mode
- [ ] Confirm RYBitten gamut selector is visible on load
- [ ] Test that harvey hue transformation works correctly
- [ ] Verify HSV option is no longer present in the dropdown

🤖 Generated with [Claude Code](https://claude.ai/code)